### PR TITLE
Spring based animations

### DIFF
--- a/Sample App/AnimationPlanner-Sample.xcodeproj/project.pbxproj
+++ b/Sample App/AnimationPlanner-Sample.xcodeproj/project.pbxproj
@@ -27,7 +27,7 @@
 		3EF52D652848AEC8000F8222 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		3EF52D682848AEC8000F8222 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		3EF52D6A2848AEC8000F8222 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		3EF52D772848B070000F8222 /* AnimationPlanner */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = AnimationPlanner; path = ../..; sourceTree = "<group>"; };
+		3EF52D772848B070000F8222 /* AnimationPlanner */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = AnimationPlanner; path = ..; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */

--- a/Sample App/AnimationPlanner-Sample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Sample App/AnimationPlanner-Sample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "SwiftDocCPlugin",
+        "repositoryURL": "https://github.com/apple/swift-docc-plugin",
+        "state": {
+          "branch": null,
+          "revision": "3303b164430d9a7055ba484c8ead67a52f7b74f6",
+          "version": "1.0.0"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Sample App/AnimationPlanner-Sample/ViewController.swift
+++ b/Sample App/AnimationPlanner-Sample/ViewController.swift
@@ -53,7 +53,7 @@ extension ViewController {
             let view = setInitialSubviewState()
             sequence
                 .delay(0.35) // A delay waits for the given amount of seconds to start the next step
-                .add(duration: 0.5, timingFunction: .quartOut) {
+                .addSpring(duration: 0.5, damping: 0.79, initialVelocity: 0) {
                     view.alpha = 1
                     view.center.y = self.view.bounds.midY
                 }
@@ -64,7 +64,7 @@ extension ViewController {
                     view.backgroundColor = .systemRed
                 }
                 .delay(0.2)
-                .add(duration: 0.12, timingFunction: .backOut) {
+                .addSpring(duration: 0.25, damping: 0.52, initialVelocity: 0) {
                     view.backgroundColor = .systemBlue
                     view.layer.cornerRadius = 0
                     view.transform = .identity

--- a/Sample App/AnimationPlanner-Sample/ViewController.swift
+++ b/Sample App/AnimationPlanner-Sample/ViewController.swift
@@ -193,7 +193,7 @@ extension AnimationSequence {
         }
         let count = 50
         let maxRadius: CGFloat = 4
-        for index in 0..count {
+        for index in 0..<count {
             let radius = CGFloat(index) / CGFloat(count) * maxRadius
             add(duration: 0.015, timingFunction: .quintInOut) {
                 view.transform = baseTransform

--- a/Sources/AnimationPlanner/Documentation.docc/AnimationPlanner.md
+++ b/Sources/AnimationPlanner/Documentation.docc/AnimationPlanner.md
@@ -7,6 +7,7 @@ Chain multiple `UIView` animations with a declarative syntax, describing each st
 Use the extension method ``StepAnimatable/animateSteps(_:completion:)-8lxza`` (made available through `UIView.animateSteps(_:completion:)`) to begin your animation sequence. Use the provided ``AnimationSequence`` object to add each steps. Posible steps are:
 - Delay ``AnimationSequence/delay(_:)``: add a delay step which pauses the sequences for the given amount of seconds
 - Animation ``AnimationSequence/add(duration:options:timingFunction:animations:)``: add an animation step with a duration and optionally animation options and a timing function
+- Spring animation ``AnimationSequence/addSpring(duration:delay:damping:initialVelocity:options:animations:)``: add a spring-based animation step with the expected damping and velocity values. Timing curves aren‘t available in this method by design, the spring itself should do all the interpolating.
 - Group ``AnimationSequence/addGroup(with:)``: add an animation group (See ``AnimationSequence/Group``) where each animation added to this group animates at the same time
 
 ## Topics

--- a/Tests/AnimationPlannerTests/AnimationPlannerTests.swift
+++ b/Tests/AnimationPlannerTests/AnimationPlannerTests.swift
@@ -51,6 +51,7 @@ final class AnimationPlannerTests: XCTestCase {
     }
 }
 
+// MARK: - Direct UIView animations
 extension AnimationPlannerTests {
     
     func testUIViewAnimation() {
@@ -73,6 +74,9 @@ extension AnimationPlannerTests {
             }
         }
     }
+}
+    
+extension AnimationPlannerTests {
     
     func testNoopSequenceAnimation() {
         runAnimationTest { completion, duration, _ in
@@ -91,6 +95,18 @@ extension AnimationPlannerTests {
         runAnimationTest { completion, duration, _ in
             UIView.animateSteps { sequence in
                 sequence.add(duration: duration) {
+                    self.performRandomAnimation()
+                }
+            } completion: { finished in
+                completion(finished)
+            }
+        }
+    }
+    
+    func testBasicSpringAnimation() {
+        runAnimationTest { completion, usedDuration, usedPrecision in
+            UIView.animateSteps { sequence in
+                sequence.addSpring(duration: usedDuration, damping: 0.86, initialVelocity: 0.2) {
                     self.performRandomAnimation()
                 }
             } completion: { finished in


### PR DESCRIPTION
Adding methods to add spring-based animations to sequences. Using `UIView.animate(duration:delay:withSpringDamping:initialVelocity:)` method instead of the standard animation method.