### PR TITLE
Deprecate `animateSteps` - Phase 2

### DIFF
--- a/Sources/AnimationPlanner/AnimationPlanner.swift
+++ b/Sources/AnimationPlanner/AnimationPlanner.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-/// (Used in making animation sequences without needing ``AnimationBuilder``)
+/// (Deprecated, uses intermediate classes instead of ``AnimationBuilder``)
 /// This class is used to add steps to your animation sequence. When starting a sequence animation with `UIView.animateSteps(_:completion:)`, a sequence object is made available through the `addSteps` closure, From within this closure each step should be added to the sequence object.
 ///
 /// Each method on ``AnimationSequence`` returns a reference to `Self`, enabling the use of chainging each method call.
@@ -91,7 +91,6 @@ extension AnimationSequence {
         
         if delay > 0 {
             fatalError("Delay here is not supported")
-//            steps.append(spring.delayed(delay))
         } else {
             steps.append(spring)
         }
@@ -215,7 +214,9 @@ extension AnimationSequence {
         @discardableResult public func animateSteps(_ addSteps: (AnimationSequence) -> Void) -> Self {
             let sequence = AnimationSequence()
             addSteps(sequence)
-            animations.append(contentsOf: sequence.steps.compactMap { $0 as? GroupAnimatable })
+            animations.append (
+                Sequence(delay: 0, animations: sequence.steps)
+            )
             return self
         }
     }

--- a/Sources/AnimationPlanner/AnimationPlanner.swift
+++ b/Sources/AnimationPlanner/AnimationPlanner.swift
@@ -16,55 +16,7 @@ import UIKit
 public class AnimationSequence {
     
     /// All steps currently added to the sequence
-    public internal(set) var steps: [Step] = []
-    
-    /// A step for each animation in the sequence. These steps are created when using the available methods on ``AnimationSequence``.
-    public enum Step {
-        /// A step that merely adds a delay, accumulated to be applied to the next step with actual animations.
-        /// - Parameter duration: Duration of the delay in seconds
-        case delay(duration: TimeInterval)
-        
-        /// An animation step that results in a `UIView.animate()` call with all the necessary parameters
-        /// - Parameter duration: Duration of the animation
-        /// - Parameter delay: Delay for the animation, only used in some specific cases
-        /// - Parameter options: Animation options, when `.repeats` make sure to set a limit or any subsequent next step might not be executed
-        /// - Parameter timingFunction: `CAMediaTimingFunction` to apply to animation, will wrap animation in `CATransaction`
-        /// - Parameter animations: Closure in which values to animate should be changed
-        case animation(
-            duration: TimeInterval,
-            delay: TimeInterval,
-            options: UIView.AnimationOptions? = [],
-            timingFunction: CAMediaTimingFunction? = nil,
-            animations: () -> Void)
-        
-        /// An spring-based animation step that results in the appropriate `UIView.animate()` call with all the necessary parameters
-        /// - Parameter duration: Duration of the animation
-        /// - Parameter delay: Delay for the animation, only used in some specific cases
-        /// - Parameter dampingRatio: Daming ratio for the spring animation
-        /// - Parameter velocity: Relative initial velocity for the spring animation
-        /// - Parameter options: Animation options, when `.repeats` make sure to set a limit or any subsequent next step might not be executed
-        /// - Parameter animations: Closure in which values to animate should be changed
-        case springAnimation(
-            duration: TimeInterval,
-            delay: TimeInterval,
-            dampingRatio: CGFloat,
-            velocity: CGFloat,
-            options: UIView.AnimationOptions? = [],
-            animations: () -> Void)
-        
-        /// A step where preparations or side-effects can be handled. Comparable to a 0-duration animation, without actually being
-        /// animated in a `UIView` animation closure.
-        case extra(delay: TimeInterval, handler: () -> Void)
-        
-        /// Step that contains group of animation steps, all of which should be performed simultaneously
-        /// - Parameter animations: All the steps to animate at the same time
-        case group(animations: [Self])
-        
-        /// A step holding another animation sequence, only to be used in an animation group
-        /// - Parameters:
-        ///   - sequence: ``AnimationSequence`` object to be added to the group
-        case sequence(sequence: AnimationSequence)
-    }
+    public internal(set) var steps: [SequenceAnimatable] = []
 }
 
 /// Extension methods that start an animation sequence, added to `UIView` by default
@@ -76,6 +28,7 @@ public protocol StepAnimatable {
     /// - Parameters:
     ///   - addSteps: Closure used to add steps to the provided `Sequence` object
     ///   - completion: Executed when the last animation has finished.
+    @available(*, deprecated, message: "Use `AnimationPlanner.plan` instead")
     static func animateSteps(_ addSteps: (AnimationSequence) -> Void, completion: ((Bool) -> Void)?)
 
     /// Start a group animation where you add each animation is performed concurrently. Use the provided `Group` object
@@ -84,12 +37,8 @@ public protocol StepAnimatable {
     /// - Parameters:
     ///   - addAnimations: Closure used to add animations to the provided `Group` object
     ///   - completion: Executed when the longest animation has finished.
-    static func animateGroup(_ addAnimations: (AnimationSequence.Group) -> Void, completion: ((Bool) -> Void)?)
-}
-
-internal protocol AnimationStep {
-    var duration: TimeInterval { get }
-    func animate(withDelay delay: TimeInterval, completion: ((Bool) -> Void)?)
+    @available(*, deprecated, message: "Use `AnimationPlanner.group` instead")
+    static func animateGroup(_ addAnimations: (AnimationSequence.SequenceGroup) -> Void, completion: ((Bool) -> Void)?)
 }
 
 extension AnimationSequence {
@@ -111,7 +60,8 @@ extension AnimationSequence {
         animations: @escaping () -> Void
     ) -> Self {
         steps.append(
-            .animation(duration: duration, delay: 0, options: options, timingFunction: timingFunction, animations: animations)
+            Animate(duration: duration, timingFunction: timingFunction, changes: animations)
+                .options(options)
         )
         return self
     }
@@ -136,9 +86,15 @@ extension AnimationSequence {
         options: UIView.AnimationOptions = [],
         animations: @escaping () -> Void
     ) -> Self {
-        steps.append(
-            .springAnimation(duration: duration, delay: delay, dampingRatio: dampingRatio, velocity: velocity, animations: animations)
-        )
+        let spring = AnimateSpring(duration: duration, dampingRatio: dampingRatio, initialVelocity: velocity, changes: animations)
+            .options(options)
+        
+        if delay > 0 {
+            fatalError("Delay here is not supported")
+//            steps.append(spring.delayed(delay))
+        } else {
+            steps.append(spring)
+        }
         return self
     }
     
@@ -150,7 +106,7 @@ extension AnimationSequence {
     /// - Returns: Returns `Self`, enabling the use of chaining mulitple calls
     @discardableResult public func delay(_ duration: TimeInterval) -> Self {
         steps.append(
-            .delay(duration: duration)
+            Wait(duration)
         )
         return self
     }
@@ -162,7 +118,9 @@ extension AnimationSequence {
     /// - Parameter handler: Closure exectured at the specific time in the sequence
     /// - Returns: Returns `Self`, enabling the use of chaining mulitple calls
     @discardableResult public func extra(_ handler: @escaping () -> Void) -> Self {
-        steps.append(.extra(delay: 0, handler: handler))
+        steps.append(
+            Extra(perform: handler)
+        )
         return self
     }
 }
@@ -170,10 +128,10 @@ extension AnimationSequence {
 extension AnimationSequence {
     
     /// Group of animation steps, all of which should be performed simultaneously
-    public class Group {
+    public class SequenceGroup {
         
         /// All animations currently added to the sequence
-        public internal(set) var animations: [Step] = []
+        public internal(set) var animations: [GroupAnimatable] = []
         
         /// Adds an animation to the animation group with all the available options.
         ///
@@ -193,8 +151,13 @@ extension AnimationSequence {
             timingFunction: CAMediaTimingFunction? = nil,
             animations: @escaping () -> Void
         ) -> Self {
+            var delayed = AnimateDelayed(delay: delay, duration: duration, changes: animations)
+                .options(options)
+            if let timingFunction = timingFunction {
+                delayed = delayed.timingFunction(timingFunction)
+            }
             self.animations.append(
-                .animation(duration: duration, delay: delay, options: options, timingFunction: timingFunction, animations: animations)
+                delayed
             )
             return self
         }
@@ -219,7 +182,9 @@ extension AnimationSequence {
             animations: @escaping () -> Void
         ) -> Self {
             self.animations.append(
-                .springAnimation(duration: duration, delay: delay, dampingRatio: dampingRatio, velocity: velocity, animations: animations)
+                AnimateSpring(duration: duration, dampingRatio: dampingRatio, initialVelocity: velocity, changes: animations)
+                    .delayed(delay)
+                    .options(options)
             )
             return self
         }
@@ -230,7 +195,10 @@ extension AnimationSequence {
         /// - Parameter handler: Closure exectured at the specific time in the sequence
         /// - Returns: Returns `Self`, enabling the use of chaining mulitple calls
         @discardableResult public func extra(delay: TimeInterval = 0, handler: @escaping () -> Void) -> Self {
-            animations.append(.extra(delay: delay, handler: handler))
+            animations.append(
+                Extra(perform: handler)
+                    .delayed(delay)
+            )
             return self
         }
         
@@ -247,7 +215,7 @@ extension AnimationSequence {
         @discardableResult public func animateSteps(_ addSteps: (AnimationSequence) -> Void) -> Self {
             let sequence = AnimationSequence()
             addSteps(sequence)
-            animations.append(.sequence(sequence: sequence))
+            animations.append(contentsOf: sequence.steps.compactMap { $0 as? GroupAnimatable })
             return self
         }
     }
@@ -259,124 +227,13 @@ extension AnimationSequence {
     /// Adds a group of animations, all of which will be executed add once.
     /// - Parameter addAnimations: Closure used to add animations to the provided `Group` object
     /// - Returns: Returns `Self`, enabling the use of chaining mulitple calls
-    @discardableResult public func addGroup(with addAnimations: (Group) -> Void) -> Self {
-        let group = Group()
+    @discardableResult public func addGroup(with addAnimations: (SequenceGroup) -> Void) -> Self {
+        let group = SequenceGroup()
         addAnimations(group)
         steps.append(
-            .group(animations: group.animations)
+            Group(animations: group.animations)
         )
         return self
-    }
-}
-
-// MARK: - Actual animation logic
-extension AnimationSequence.Step: AnimationStep {
-    
-    /// Full duration for each step type, uses longest duration of animations in a group
-    public var duration: TimeInterval {
-        switch self {
-        case .animation(let duration, let delay, _, _, _), .springAnimation(let duration, let delay, _, _, _, _):
-            return duration + delay
-        case .delay(let delay), .extra(let delay, _):
-            return delay
-        case .group(let steps):
-            guard let longestDuration = steps.map({ $0.duration }).max() else {
-                return 0
-            }
-            return longestDuration
-        case .sequence(let sequence):
-            return sequence.duration
-        }
-        
-    }
-    
-    /// Perform the animation for this step
-    ///
-    /// Wraps animation steps with a `timingFunction` in a `CATransaction` commit
-    /// - Parameters:
-    ///   - delay: Time in seconds to wait to perform the animation
-    ///   - completion: Closure to be executed when animation has finished
-    func animate(
-        withDelay leadingDelay: TimeInterval,
-        completion: ((Bool) -> Void)?
-    ) {
-        switch self {
-        case .animation(let duration, let delay, let options, let timingFunction, let animations):
-            let createAnimations: (((Bool) -> Void)?) -> Void = { completion in
-                UIView.animate(
-                    withDuration: duration,
-                    delay: leadingDelay + delay,
-                    options: options ?? [],
-                    animations: animations,
-                    completion: completion
-                )
-            }
-            
-            if let timingFunction = timingFunction {
-                CATransaction.begin()
-                CATransaction.setAnimationDuration(duration)
-                CATransaction.setAnimationTimingFunction(timingFunction)
-                
-                createAnimations(completion)
-                
-                CATransaction.commit()
-            } else {
-                createAnimations(completion)
-            }
-        case .springAnimation(let duration, let delay, let dampingRatio, let velocity, let options, let animations):
-            UIView.animate(
-                withDuration: duration,
-                delay: leadingDelay + delay,
-                usingSpringWithDamping: dampingRatio,
-                initialSpringVelocity: velocity,
-                options: options ?? [],
-                animations: animations,
-                completion: completion
-            )
-        case .extra(let delay, let handler):
-            // Perform handler with the optional delay
-            let perform = {
-                handler()
-                completion?(true)
-            }
-            let peformDelay = leadingDelay + delay
-            if peformDelay > 0 {
-                DispatchQueue.main.asyncAfter(deadline: .now() + peformDelay, execute: perform)
-            } else {
-                perform()
-            }
-        case .group(let steps):
-            let sortedSteps = Array(steps.sorted(by: { $0.duration < $1.duration }))
-            guard let longestStep = sortedSteps.last else {
-                // No sequences to animate, call completion
-                completion?(true)
-                return
-            }
-            sortedSteps.dropLast().forEach { step in
-                step.animate(withDelay: leadingDelay, completion: nil)
-            }
-            // Animate the longest sequence with the completion, so the completion closure
-            // is executed when all sequences _should_ be completed
-            longestStep.animate(withDelay: leadingDelay, completion: completion)
-        case .sequence(let sequence):
-            sequence.animate(
-                withDelay: leadingDelay,
-                completion: completion)
-        case .delay(_):
-            fatalError("Delay steps should not be animated")
-        }
-    }
-}
-
-extension AnimationSequence: AnimationStep {
-
-    /// Total duration of all steps in the sequence combined
-    public var duration: TimeInterval {
-        steps.reduce(0, { $0 + $1.duration })
-    }
-
-    internal func animate(withDelay delay: TimeInterval, completion: ((Bool) -> Void)?) {
-        UIView.animate(remainingSteps: steps, startingDelay: delay, completion: completion)
     }
 }
 
@@ -389,85 +246,26 @@ extension StepAnimatable {
         // hopefully resulting in steps added to the sequence
         addSteps(sequence)
         
-        // Start animating all the steps
-        sequence.animate(withDelay: 0, completion: completion)
+        let runningSequence = RunningSequence(animations: sequence.steps)
+        runningSequence.onComplete { finished in
+            completion?(finished)
+        }
+        runningSequence.animate()
     }
     
-    public static func animateGroup(_ addAnimations: (AnimationSequence.Group) -> Void, completion: ((Bool) -> Void)? = nil) {
-        animateSteps({ sequence in
-            // Just add one group step with the addAnimations closure
-            sequence.addGroup(with: addAnimations)
-        }, completion: completion)
+    public static func animateGroup(_ addAnimations: (AnimationSequence.SequenceGroup) -> Void, completion: ((Bool) -> Void)? = nil) {
+        
+        let group = AnimationSequence.SequenceGroup()
+        addAnimations(group)
+        
+        let runningSequence = RunningSequence(animations: [Group(animations: group.animations)])
+        runningSequence.onComplete { finished in
+            completion?(finished)
+        }
+        runningSequence.animate()
     }
 }
 
 /// Applying ``StepAnimatable``  to `UIView`
+@available(*, deprecated, message: "Use `AnimationPlanner.plan` instead")
 extension UIView: StepAnimatable { }
-
-extension StepAnimatable {
-    
-    /// Recursive method that calls itself with less remaining steps each time
-    /// - Parameters:
-    ///   - steps: Array of steps that needs to be animated
-    ///   - completion: Completion closure to be executed when last step has finished
-    static func animate(remainingSteps steps: [AnimationSequence.Step], startingDelay: TimeInterval = 0, completion: ((Bool) -> Void)? = nil) {
-        
-        var cummulativeDelay: TimeInterval = startingDelay
-        
-        // Drop any initial steps with just a delay, but keep track of their delay
-        let animatableSteps = steps.drop { step in
-            if case let .delay(delay) = step {
-                cummulativeDelay += delay
-                return true
-            }
-            return false
-        }
-        
-        guard let step = animatableSteps.first else {
-            // When there‘s no more steps available, there‘s no more animations to be done
-            guard let completion = completion else {
-                // No completion closure to call
-                return
-            }
-
-            if cummulativeDelay > 0 {
-                // Wait out the remaing delay until calling completion closure
-                DispatchQueue.main.asyncAfter(deadline: .now() + cummulativeDelay) {
-                    completion(true)
-                }
-            } else {
-                completion(true)
-            }
-            return
-        }
-        
-        let remainingSteps = animatableSteps.dropFirst()
-        let startTime = CACurrentMediaTime()
-        
-        // Actually perform animations for first remaining step,
-        // delaying for the accumulated delay of possible previous delay steps
-        step.animate(withDelay: cummulativeDelay) { finished in
-            guard finished else {
-                completion?(finished)
-                return
-            }
-            
-            let actualDuration = CACurrentMediaTime() - startTime
-            let difference = (step.duration + cummulativeDelay) - actualDuration
-            let oneFrameDifference: TimeInterval = 1/60
-            
-            guard difference <= 0.1 || actualDuration > oneFrameDifference else {
-                // UIView animation probably wasn‘t executed because no actual animatable
-                // properties were changed in animation closure. Just wait out remaining time
-                // before moving over to the next step.
-                let waitTime = max(0, difference - oneFrameDifference) // reduce a frame to be safe
-                DispatchQueue.main.asyncAfter(deadline: .now() + waitTime) {
-                    animate(remainingSteps: Array(remainingSteps), completion: completion)
-                }
-                return
-            }
-            // Recursively call this class method again with the remaining steps
-            animate(remainingSteps: Array(remainingSteps), completion: completion)
-        }
-    }
-}

--- a/Sources/AnimationPlanner/Animations/Animates.swift
+++ b/Sources/AnimationPlanner/Animations/Animates.swift
@@ -30,7 +30,7 @@ extension GroupAnimatable {
     public func asGroup() -> [GroupAnimatable] { [self] }
 }
 
-/// Adds a delay to the animation
+/// Adds a delaying functionality to an animation. Delayed animations can only be added in a grouped context, where each animation is performed simultaneously. Adding a delay to a sequence animation can be done by preceding it with a ``Wait`` struct.
 public protocol DelayedAnimatable: GroupAnimatable {
     /// Delay in seconds after which the animation should start
     var delay: TimeInterval { get }

--- a/Sources/AnimationPlanner/Animations/Builder.swift
+++ b/Sources/AnimationPlanner/Animations/Builder.swift
@@ -34,9 +34,8 @@ public struct AnimationPlanner {
     public static func plan(
         @AnimationBuilder animations builder: () -> [SequenceAnimatable]
     ) -> RunningSequence {
-        let running = RunningSequence(animations: builder())
-        running.animate()
-        return running
+        RunningSequence(animations: builder())
+            .animate()
     }
     
     /// Start a new group animation where animations added will be performed simultaneously, meaning all animations run at the same time.

--- a/Sources/AnimationPlanner/Animations/PerformAnimations.swift
+++ b/Sources/AnimationPlanner/Animations/PerformAnimations.swift
@@ -84,7 +84,7 @@ extension AnimateSpring: PerformsAnimations {
     }
 }
 
-extension AnimateDelayed: PerformsAnimations where Contained: Animation {
+extension AnimateDelayed: PerformsAnimations where Contained: PerformsAnimations {
     public func animate(delay leadingDelay: TimeInterval, completion: ((Bool) -> Void)?) {
         animation.animate(delay: delay + leadingDelay, completion: completion)
     }

--- a/Sources/AnimationPlanner/Animations/PerformAnimations.swift
+++ b/Sources/AnimationPlanner/Animations/PerformAnimations.swift
@@ -17,6 +17,9 @@ public protocol PerformsAnimations {
 extension Animate: PerformsAnimations {
     public func animate(delay leadingDelay: TimeInterval, completion: ((Bool) -> Void)?) {
         let duration: TimeInterval
+        
+        // FIXME: `DelayedAnimatable` should not be checked here
+        // Maybe parse animation delays before calling more specific method with delay and duration
         if let delayed = self as? DelayedAnimatable {
             duration = delayed.originalDuration
         } else {
@@ -65,6 +68,9 @@ extension AnimateSpring: PerformsAnimations {
     public func animate(delay leadingDelay: TimeInterval, completion: ((Bool) -> Void)?) {
         let duration: TimeInterval
         let delay: TimeInterval
+        
+        // FIXME: `DelayedAnimatable` should not be checked here
+        // Maybe parse animation delays before calling more specific method with delay and duration
         if let delayed = self as? DelayedAnimatable {
             duration = delayed.originalDuration
             delay = delayed.delay

--- a/Sources/AnimationPlanner/Animations/RunningSequence.swift
+++ b/Sources/AnimationPlanner/Animations/RunningSequence.swift
@@ -46,9 +46,11 @@ public extension RunningSequence {
 
 extension RunningSequence {
     
-    func animate(delay: TimeInterval = 0) {
+    @discardableResult
+    func animate(delay: TimeInterval = 0) -> Self {
         remainingAnimations = Array(animations)
         animateNextAnimation(initialDelay: delay)
+        return self
     }
     
     func animateNextAnimation(initialDelay: TimeInterval = 0) {

--- a/Tests/AnimationPlannerTests/AnimationPlannerTests.swift
+++ b/Tests/AnimationPlannerTests/AnimationPlannerTests.swift
@@ -85,7 +85,7 @@ extension Array where Element == TimeInterval {
 
 extension AnimationPlannerTests {
     
-    class var randomDuration: TimeInterval { TimeInterval.random(in: 0.2...0.8) }
+    class var randomDuration: TimeInterval { TimeInterval.random(in: 0.2...0.6) }
     var randomDuration: TimeInterval { Self.randomDuration }
     
     class func randomDurations(amount: Int) -> [TimeInterval] { (0..<amount).map({ _ in randomDuration }) }

--- a/Tests/AnimationPlannerTests/AnimationPlannerTests.swift
+++ b/Tests/AnimationPlannerTests/AnimationPlannerTests.swift
@@ -74,6 +74,15 @@ fileprivate extension CGFloat {
     static var large: Self { Self.random(in: largeRange) }
 }
 
+extension Array where Element == TimeInterval {
+    func totalDuration() -> Element {
+        reduce(0, +)
+    }
+    func longestDuration() -> Element {
+        self.max()!
+    }
+}
+
 extension AnimationPlannerTests {
     
     class var randomDuration: TimeInterval { TimeInterval.random(in: 0.2...0.8) }

--- a/Tests/AnimationPlannerTests/ComplexAnimationTests.swift
+++ b/Tests/AnimationPlannerTests/ComplexAnimationTests.swift
@@ -46,7 +46,7 @@ class ComplexAnimationTest: AnimationPlannerTests {
         
     }
     
-    func testNewSequenceGroup () {
+    func testSimplifiedSequenceGroup () {
         
         let numberOfGroups = 2
         let numberOfSequences = 2


### PR DESCRIPTION
‘Old’ API now uses newer result builder logic behind the scenes. All tests now use new API albeit implicitly.

- added more tests to debug failing complexer tests
- renamed a lot or protocols to use `Animatable` instead of `Animates`
- completed `RunningAnimation` implementation