### PR TITLE
*Actually* stopping animations

### DIFF
--- a/Sample App/AnimationPlanner-Sample.xcodeproj/project.pbxproj
+++ b/Sample App/AnimationPlanner-Sample.xcodeproj/project.pbxproj
@@ -17,7 +17,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		3E5C6DA62848C27B00720FE8 /* CAMediaTimingFunction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CAMediaTimingFunction.swift; sourceTree = "<group>"; };
 		3EF52D592848AEC7000F8222 /* AnimationPlanner-Sample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "AnimationPlanner-Sample.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3EF52D5C2848AEC7000F8222 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		3EF52D5E2848AEC7000F8222 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -72,7 +71,6 @@
 				3EF52D5C2848AEC7000F8222 /* AppDelegate.swift */,
 				3EF52D5E2848AEC7000F8222 /* SceneDelegate.swift */,
 				3EF52D602848AEC7000F8222 /* ViewController.swift */,
-				3E5C6DA62848C27B00720FE8 /* CAMediaTimingFunction.swift */,
 				3EF52D622848AEC7000F8222 /* Main.storyboard */,
 				3EF52D652848AEC8000F8222 /* Assets.xcassets */,
 				3EF52D672848AEC8000F8222 /* LaunchScreen.storyboard */,

--- a/Sample App/AnimationPlanner-Sample/ViewController.swift
+++ b/Sample App/AnimationPlanner-Sample/ViewController.swift
@@ -15,6 +15,9 @@ class ViewController: UIViewController {
         view.layer.cornerCurve = .continuous
         return view
     }()
+    
+    lazy var stopButton = newStopButton()
+    lazy var resetButton = newResetButton()
 	
     // Sequence currently performing animations
     var runningSequence: RunningSequence?
@@ -245,8 +248,9 @@ extension ViewController {
     }
 }
 
-extension ViewController {
-    lazy var stopButton: UIButton = {
+private extension ViewController {
+    
+    func newStopButton() -> UIButton {
         var configuration = UIButton.Configuration.filled()
         configuration.buttonSize = .large
         configuration.baseBackgroundColor = .systemRed
@@ -256,9 +260,9 @@ extension ViewController {
             runningSequence?.stopAnimations()
             resetButton.isEnabled = true
         })
-    }()
+    }
     
-    lazy var resetButton: UIButton = {
+    func newResetButton() -> UIButton {
         var configuration = UIButton.Configuration.filled()
         configuration.buttonSize = .large
         configuration.baseBackgroundColor = .systemGreen
@@ -269,7 +273,7 @@ extension ViewController {
         })
         button.isEnabled = false
         return button
-    }()
+    }
 }
 
 extension UIView {

--- a/Sample App/AnimationPlanner-Sample/ViewController.swift
+++ b/Sample App/AnimationPlanner-Sample/ViewController.swift
@@ -22,7 +22,7 @@ class ViewController: UIViewController {
     // Sequence currently performing animations
     var runningSequence: RunningSequence?
     
-    let testStopping: Bool = false // Set to true to display buttons to stop and reset animations
+    let testStopping: Bool = true // Set to true to display buttons to stop and reset animations
     
     let performComplexAnimation: Bool = false // Set to true to run a more complex animation
     
@@ -67,8 +67,11 @@ extension ViewController {
     func runSimpleBuilderAnimation() {
         let view = setInitialSubviewState()
         runningSequence = AnimationPlanner.plan {
-            Wait(0.35) // A delay waits for the given amount of seconds to start the next step
-            Animate(duration: 0.32, timingFunction: .quintOut) {
+//            Wait(0.35) // A delay waits for the given amount of seconds to start the next step
+            Extra {
+                print("Doing absolutely nothing....")
+            }
+            Animate(duration: 2, timingFunction: .quintOut) {
                 view.alpha = 1
                 view.center.y = self.view.bounds.midY
             }

--- a/Sample App/AnimationPlanner-Sample/ViewController.swift
+++ b/Sample App/AnimationPlanner-Sample/ViewController.swift
@@ -15,42 +15,55 @@ class ViewController: UIViewController {
         view.layer.cornerCurve = .continuous
         return view
     }()
+	
+    // Sequence currently performing animations
+    var runningSequence: RunningSequence?
     
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        view.addSubview(subview)
-    }
-
+    let testStopping: Bool = false // Set to true to display buttons to stop and reset animations
+    
     let performComplexAnimation: Bool = false // Set to true to run a more complex animation
-
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
+    
+    func performAnimations() {
+        resetButton.isEnabled = false
         if performComplexAnimation {
             runComplexBulderAnimation()
         } else {
             runSimpleBuilderAnimation()
         }
     }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        performAnimations()
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.addSubview(subview)
+        
+        guard testStopping else {
+            return
+        }
+        view.addSubview(stopButton)
+        view.addSubview(resetButton)
+        stopButton.translatesAutoresizingMaskIntoConstraints = false
+        resetButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            stopButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            stopButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            stopButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerXAnchor, constant: -8),
+            resetButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerXAnchor, constant: 8),
+            resetButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            resetButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor)
+        ])
+    }
 }
 
 extension ViewController {
     
-    func setInitialSubviewState() -> UIView {
-        subview.alpha = 0
-        subview.transform = .identity
-        subview.frame.size = CGSize(width: 100, height: 100)
-        subview.center.x = view.bounds.midX
-        subview.frame.origin.y = view.bounds.minY
-        subview.backgroundColor = .systemOrange
-        subview.layer.cornerRadius = 16
-        subview.layer.borderWidth = 0
-        subview.layer.borderColor = nil
-        return subview
-    }
-    
     func runSimpleBuilderAnimation() {
         let view = setInitialSubviewState()
-        AnimationPlanner.plan {
+        runningSequence = AnimationPlanner.plan {
             Wait(0.35) // A delay waits for the given amount of seconds to start the next step
             Animate(duration: 0.32, timingFunction: .quintOut) {
                 view.alpha = 1
@@ -75,8 +88,10 @@ extension ViewController {
                 view.frame.origin.y = self.view.bounds.maxY
             }.timingFunction(.circIn)
         }.onComplete { finished in
-            // Just to keep the flow going, let‘s run the animation again
-            self.runSimpleBuilderAnimation()
+			if finished {
+				// Just to keep the flow going, let‘s run the animation again
+				self.runSimpleBuilderAnimation()
+			}
         }
     }
     
@@ -84,7 +99,7 @@ extension ViewController {
     func runComplexBulderAnimation() {
         var sneakyCopy: UIView! // Don‘t worry, you‘ll see later
         
-        AnimationPlanner.plan {
+        runningSequence = AnimationPlanner.plan {
             let quarterHeight = view.bounds.height / 4
             let view = setInitialSubviewState()
             
@@ -183,12 +198,29 @@ extension ViewController {
                 sneakyCopy?.transform = view.transform.translatedBy(x: 0, y: quarterHeight)
             }
         }.onComplete { finished in
-            self.runComplexBulderAnimation()
+            if finished {
+                sneakyCopy.removeFromSuperview()
+                self.runComplexBulderAnimation()
+            }
         }
     }
 }
 
 extension ViewController {
+    
+    func setInitialSubviewState() -> UIView {
+        subview.alpha = 0
+        subview.transform = .identity
+        subview.frame.size = CGSize(width: 100, height: 100)
+        subview.center.x = view.bounds.midX
+        subview.frame.origin.y = view.bounds.minY
+        subview.backgroundColor = .systemOrange
+        subview.layer.cornerRadius = 16
+        subview.layer.borderWidth = 0
+        subview.layer.borderColor = nil
+        return subview
+    }
+    
     /// Adds a custom shake animation sequence on the provided view
     /// - Parameter view: View to which the transform should be applied
     /// - Returns: Animations to be added to the sequence
@@ -211,6 +243,33 @@ extension ViewController {
             }.timingFunction(.quintOut)
         }
     }
+}
+
+extension ViewController {
+    lazy var stopButton: UIButton = {
+        var configuration = UIButton.Configuration.filled()
+        configuration.buttonSize = .large
+        configuration.baseBackgroundColor = .systemRed
+        configuration.cornerStyle = .large
+        configuration.title = "Stop"
+        return UIButton(configuration: configuration, primaryAction: UIAction { [unowned self] _ in
+            runningSequence?.stopAnimations()
+            resetButton.isEnabled = true
+        })
+    }()
+    
+    lazy var resetButton: UIButton = {
+        var configuration = UIButton.Configuration.filled()
+        configuration.buttonSize = .large
+        configuration.baseBackgroundColor = .systemGreen
+        configuration.cornerStyle = .large
+        configuration.title = "Reset"
+        let button = UIButton(configuration: configuration, primaryAction: UIAction { [unowned self] _ in
+            performAnimations()
+        })
+        button.isEnabled = false
+        return button
+    }()
 }
 
 extension UIView {

--- a/Sources/AnimationPlanner/Animations/AnimateDelayed.swift
+++ b/Sources/AnimationPlanner/Animations/AnimateDelayed.swift
@@ -50,7 +50,16 @@ extension AnimateDelayed: Animation where Delayed: Animation { }
 extension AnimateDelayed: SpringAnimatable where Delayed: SpringAnimatable { }
 
 extension AnimateDelayed: PerformsAnimations where Contained: PerformsAnimations {
-    public func animate(delay leadingDelay: TimeInterval, completion: ((Bool) -> Void)?) {
-        animation.animate(delay: delay + leadingDelay, completion: completion)
+    public func animate(delay leadingDelay: TimeInterval, completion: ((Bool) -> Void)?) -> PerformsAnimations {
+        let animation = animation.animate(delay: delay + leadingDelay, completion: completion)
+        if let animation = animation as? Delayed {
+            return mutate { $0.animation = animation }
+        }
+        print("Animation result of \(self.animation) is \(type(of: animation)) and can not be contained by \(self)")
+        return animation
+    }
+    
+    public func stop() {
+        animation.stop()
     }
 }

--- a/Sources/AnimationPlanner/Animations/Loop.swift
+++ b/Sources/AnimationPlanner/Animations/Loop.swift
@@ -101,12 +101,6 @@ extension Loop: GroupConvertible where Looped == GroupAnimatable {
     }
 }
 
-extension Loop: PerformsAnimations where Looped == GroupAnimatable {
-    public func animate(delay leadingDelay: TimeInterval, completion: ((Bool) -> Void)?) {
-        Group(animations: animations).animate(delay: leadingDelay, completion: completion)
-    }
-}
-
 extension Swift.Sequence {
     /// Maps values from the sequence to animations
     /// - Parameter animations: Add each animation from within this closure. Animations should conform to ``GroupAnimatable``

--- a/Sources/AnimationPlanner/Animations/Sequence.swift
+++ b/Sources/AnimationPlanner/Animations/Sequence.swift
@@ -28,11 +28,16 @@ public struct Sequence: DelayedAnimatable {
 extension Sequence: DelayModifier { }
 
 extension Sequence: PerformsAnimations {
-    public func animate(delay: TimeInterval, completion: ((Bool) -> Void)?) {
+    public func animate(delay: TimeInterval, completion: ((Bool) -> Void)?) -> PerformsAnimations {
         runningSequence
             .onComplete { finished in
                 completion?(finished)
             }
             .animate(delay: delay)
+		return self
     }
+	
+	public func stop() {
+		runningSequence.stopAnimations()
+	}
 }

--- a/Sources/AnimationPlanner/Animations/Sequence.swift
+++ b/Sources/AnimationPlanner/Animations/Sequence.swift
@@ -25,6 +25,8 @@ public struct Sequence: DelayedAnimatable {
     }
 }
 
+extension Sequence: DelayModifier { }
+
 extension Sequence: PerformsAnimations {
     public func animate(delay: TimeInterval, completion: ((Bool) -> Void)?) {
         runningSequence

--- a/Sources/AnimationPlanner/Extensions/UIViewPropertyAnimator.swift
+++ b/Sources/AnimationPlanner/Extensions/UIViewPropertyAnimator.swift
@@ -1,0 +1,12 @@
+import UIKit
+
+extension UIViewPropertyAnimator {
+	convenience init(duration: TimeInterval, timingFunction: CAMediaTimingFunction, animations: @escaping () -> Void) {
+		let controlPoints: [CGPoint] = (1...2).map { index in
+			var points: [Float] = [0, 0]
+			timingFunction.getControlPoint(at: index, values: &points)
+			return CGPoint(x: CGFloat(points[0]), y: CGFloat(points[1]))
+		}
+		self.init(duration: duration, controlPoint1: controlPoints[0], controlPoint2: controlPoints[1], animations: animations)
+	}
+}

--- a/Sources/AnimationPlanner/Protocols/Animatable.swift
+++ b/Sources/AnimationPlanner/Protocols/Animatable.swift
@@ -12,8 +12,17 @@ public protocol Animation: Animatable, PerformsAnimations {
     var changes: () -> Void { get }
     /// Animation options to use for UIView animation
     var options: UIView.AnimationOptions? { get }
+    /// Whether user interaction is enabled on your parent views while this animation is running
+    var allowsUserInteraction: Bool { get }
     /// Timing function to apply to animation. Leads to the `UIView` animation being performed in a `CATransaction` wrapped animation
     var timingFunction: CAMediaTimingFunction? { get }
+}
+
+internal extension Animation {
+    /// Temporary method to use either ``allowsUserInteraction`` or get from deprecated animation options
+    var isUserInteractionEnabled: Bool {
+        allowsUserInteraction || options?.contains(.allowUserInteraction) == true
+    }
 }
 
 /// Animation that can be performed in a sequence, meaning each subsequent animation starts right after the previous completes

--- a/Sources/AnimationPlanner/Protocols/AnimationContainer.swift
+++ b/Sources/AnimationPlanner/Protocols/AnimationContainer.swift
@@ -17,6 +17,8 @@ extension AnimationContainer where Contained: Animation {
     public var changes: () -> Void { animation.changes }
     /// Forwarded ``Animation`` property for ``Animation/options``
     public var options: UIView.AnimationOptions? { animation.options }
+    /// Forwarded ``Animation`` property for ``Animation/allowsUserInteraction``
+    public var allowsUserInteraction: Bool { animation.allowsUserInteraction }
     /// Forwarded ``Animation`` property for ``Animation/timingFunction``
     public var timingFunction: CAMediaTimingFunction? { animation.timingFunction }
 }

--- a/Sources/AnimationPlanner/Protocols/PerformsAnimations.swift
+++ b/Sources/AnimationPlanner/Protocols/PerformsAnimations.swift
@@ -8,7 +8,11 @@ public protocol PerformsAnimations {
     ///   - delay: Any delay accumulated (from preceding ``Wait`` structs) leading up to the animation.
     ///   Waits for this amount of seconds before actually performing the animation
     ///   - completion: Optional closure called when animation completes
-    func animate(delay leadingDelay: TimeInterval, completion: ((_ finished: Bool) -> Void)?)
+    @discardableResult
+    func animate(delay leadingDelay: TimeInterval, completion: ((_ finished: Bool) -> Void)?) -> PerformsAnimations
+    
+    /// Cancels any currently running animations
+    func stop()
     
     /// Queries the animation and possible contained animations to find the correct timing values to use to create an actual animation
     /// - Parameter leadingDelay: Delay to add before performing animation

--- a/Sources/AnimationPlanner/RunningSequence.swift
+++ b/Sources/AnimationPlanner/RunningSequence.swift
@@ -3,7 +3,7 @@ import UIKit
 /// Maintains state about running animations and provides ways to add a completion handler or stop the animations
 public class RunningSequence {
     
-    public enum State {
+    public enum State: Equatable {
         /// Sequence is ready but not yet running animations
         case ready
         /// Sequence is performing animations
@@ -24,7 +24,7 @@ public class RunningSequence {
     public private(set) var state: State = .ready
     
     private(set) var remainingAnimations: [Animatable] = []
-    private(set) var currentAnimation: Animatable?
+    private(set) var currentAnimation: PerformsAnimations?
     
     private(set) var completionHandlers: [(Bool) -> Void] = []
     
@@ -57,19 +57,19 @@ public extension RunningSequence {
 public extension RunningSequence {
     /// Stops the currently running animation and cancels any upcoming animations
     func stopAnimations() {
-        guard case .running = state else {
-            // Only running animations can be stopped
+        let stoppabaleStates: [State] = [.ready, .running]
+        guard stoppabaleStates.contains(state) else {
+            // Only uncompleted sequences can be stopped
             return
         }
         
         state = .stopped
-        if let animation = currentAnimation as? Animation {
-            // Perform animation’s changes again to stop animation
-            animation.changes()
-        }
-        
+		currentAnimation?.stop()
+		currentAnimation = nil
+		remainingAnimations
+			.compactMap { $0 as? PerformsAnimations }
+			.forEach { $0.stop() }
         remainingAnimations.removeAll()
-        currentAnimation = nil
         
         complete(finished: false)
     }
@@ -79,7 +79,7 @@ extension RunningSequence {
     
     @discardableResult
     func animate(delay: TimeInterval = 0) -> Self {
-        guard case .ready = state else {
+        guard state == .ready else {
             // Don’t start animating a sequence with running, completed or stopped animations
             return self
         }
@@ -102,50 +102,61 @@ extension RunningSequence {
             return false
         }
         
-        currentAnimation = impendingAnimations.first
-        guard let animation = currentAnimation as? PerformsAnimations else {
-            guard leadingDelay == 0 else {
-                // Wait out the remaing delay until calling completion closure
-                DispatchQueue.main.asyncAfter(deadline: .now() + leadingDelay) {
-                    self.complete(finished: true)
-                }
-                return
-            }
-            complete(finished: true)
-            return
-        }
-        
+		guard let animation = impendingAnimations.first as? PerformsAnimations else {
+			guard leadingDelay == 0 else {
+				// Wait out the remaing delay until calling completion closure
+				DispatchQueue.main.asyncAfter(deadline: .now() + leadingDelay) {
+					self.complete(finished: true)
+				}
+				return
+			}
+			complete(finished: true)
+			return
+		}
+                
         remainingAnimations = Array(impendingAnimations.dropFirst())
-        let startTime = CACurrentMediaTime()
+        let duration = (animation as? Animatable)?.duration ?? 0
+        let completionDuration = duration + leadingDelay
         
-        animation.animate(delay: leadingDelay) { finished in
+        let startTime = CACurrentMediaTime()
+        let runningAnimation = animation.animate(delay: leadingDelay) { finished in
             guard finished else {
                 self.complete(finished: finished)
                 return
             }
             
-            if let duration = (animation as? Animatable)?.duration {
-                let actualDuration = CACurrentMediaTime() - startTime
-                let difference = (duration + leadingDelay) - actualDuration
-                let oneFrameDifference: TimeInterval = 1/60
-                
-                if difference > 0.1 && actualDuration < oneFrameDifference {
-                    // UIView animation probably wasn‘t executed because no actual animatable
-                    // properties were changed in animation closure. Just wait out remaining time
-                    // before moving over to the next step.
-                    let waitTime = max(0, difference - oneFrameDifference) // reduce a frame to be safe
-                    DispatchQueue.main.asyncAfter(deadline: .now() + waitTime) {
-                        self.animateNextAnimation()
-                    }
-                    return
+            guard completionDuration > 0 else {
+                // Skip duration checking when animation should immediately complete
+                self.animateNextAnimation()
+                return
+            }
+            
+            let actualDuration = CACurrentMediaTime() - startTime
+            let difference = (duration + leadingDelay) - actualDuration
+            let oneFrameDifference: TimeInterval = 1/60
+            
+            if difference <= 0.1 || actualDuration >= oneFrameDifference {
+                self.animateNextAnimation()
+            } else {
+                // UIView animation probably wasn‘t executed because no actual animatable
+                // properties were changed in animation closure. Just wait out remaining time
+                // before moving over to the next step.
+                let waitTime = max(0, difference - oneFrameDifference) // reduce a frame to be safe
+                DispatchQueue.main.asyncAfter(deadline: .now() + waitTime) {
+                    self.animateNextAnimation()
                 }
             }
-            self.animateNextAnimation()
+        }
+        if completionDuration > 0 {
+            // Only set current animation when its completion can‘t immediately fire,
+            // causing a newer animation to be set as `currentAnimation` right before
+            // this line is executed
+            currentAnimation = runningAnimation
         }
     }
     
     func complete(finished: Bool) {
-        if case .running = state {
+        if state == .running {
             state = .completed(finished: finished)
         }
         completionHandlers.forEach { $0(finished) }

--- a/Tests/AnimationPlannerTests/AnimationPlannerTests.swift
+++ b/Tests/AnimationPlannerTests/AnimationPlannerTests.swift
@@ -9,7 +9,7 @@ class AnimationPlannerTests: XCTestCase {
     
     override func setUp() {
         window = UIWindow(frame: UIScreen.main.bounds)
-        view = UIView(frame: window.bounds.insetBy(dx: 100, dy: 100))
+        view = newView()
         window.addSubview(view)
     }
     
@@ -20,7 +20,7 @@ class AnimationPlannerTests: XCTestCase {
         view = nil
     }
     
-    /// Runs your animation logic, waits for completion and fails when expected duration varies from provided duration (allowing for precision). Adds the completion handler to the returned `RunningSequence` object when only using `AnimationPlanner.plan` or `.group`. Othewise use `runAnimationTest`
+    /// Runs your animation logic, waits for completion and fails when expected duration varies from provided duration (allowing for precision). Adds a default completion handler to the returned `RunningSequence`.
     /// - Parameters:
     ///   - duration: Duration of animimation, or total duration of all animation steps, defaults to random duration
     ///   - precision: Precision to use when comparing expected duration and time to complete animations
@@ -31,20 +31,30 @@ class AnimationPlannerTests: XCTestCase {
     func runAnimationBuilderTest(
         duration: TimeInterval = randomDuration,
         precision: TimeInterval = durationPrecision,
+        expectFinished: Bool = true,
         _ animations: @escaping (
             _ usedDuration: TimeInterval,
             _ usedPrecision: TimeInterval) -> RunningSequence?
     ) {
-        runAnimationTest(duration: duration, precision: precision) { completion, usedDuration, usedPrecision in
+        runAnimationTest(duration: duration, precision: precision, expectFinished: expectFinished) { completion, usedDuration, usedPrecision in
             let runningSequence = animations(duration, precision)
             XCTAssertNotNil(runningSequence)
             runningSequence?.onComplete(completion)
         }
     }
     
+    /// Runs your animation logic, waits for completion and fails when expected duration varies from provided duration (allowing for precision). Add the completion handler to the returned `RunningSequence` object when only using `AnimationPlanner.plan` or `.group`. Othewise use `runAnimationTest`
+    /// - Parameters:
+    ///   - duration: Duration of animimation, or total duration of all animation steps, defaults to random duration
+    ///   - precision: Precision to use when comparing expected duration and time to complete animations
+    ///   - animations: Closure where animations should be performed with completion closure to call when completed
+    ///   - completion: Closure to call when animations have completed
+    ///   - usedDuration: Duration for animation, use this argument when no specific duration is provided
+    ///   - usedPrecision: Precision for duration check, use this argument when no specific precision is provided
     func runAnimationTest(
         duration: TimeInterval = randomDuration,
         precision: TimeInterval = durationPrecision,
+        expectFinished: Bool = true,
         _ animations: @escaping (
             _ completion: @escaping (Bool) -> Void,
             _ usedDuration: TimeInterval,
@@ -54,7 +64,13 @@ class AnimationPlannerTests: XCTestCase {
         let startTime = CACurrentMediaTime()
         
         let completion: (Bool) -> Void = { finished in
-            XCTAssert(finished, "Animation not finished")
+            if finished != expectFinished {
+                if expectFinished {
+                    XCTFail("Animations should complete finished")
+                } else {
+                    XCTFail("Animations should complete interrupted")
+                }
+            }
             assertDifference(startTime: startTime, duration: duration, precision: precision)
             finishedExpectation.fulfill()
         }
@@ -110,6 +126,7 @@ extension AnimationPlannerTests {
         let duration: TimeInterval
         var totalDuration: TimeInterval { delay + duration }
     }
+    
     func randomDelayedAnimations(amount: Int) -> [RandomAnimation] {
         zip(
             randomDurations(amount: amount),
@@ -122,7 +139,12 @@ extension AnimationPlannerTests {
     }
     
     func newView() -> UIView {
-        let view = UIView()
+        let view = UIView(frame: CGRect(
+            x: .large,
+            y: .large,
+            width: .large,
+            height: .large
+        ))
         window.addSubview(view)
         return view
     }

--- a/Tests/AnimationPlannerTests/BuilderTests.swift
+++ b/Tests/AnimationPlannerTests/BuilderTests.swift
@@ -18,12 +18,16 @@ class BuilderTests: AnimationPlannerTests {
         let delay = spring.delayed(3)
         XCTAssertEqual(delay.duration, spring.duration + delay.delay)
         
-        let options: UIView.AnimationOptions = .allowAnimatedContent
-        let editedDelay = delay.options(options)
+        // By default this should be false
+        XCTAssertEqual(delay.allowsUserInteraction, false)
+        
+        let editedDelay = delay.allowUserInteraction()
         let containedAnimation = editedDelay.animation.animation
         let springed = editedDelay.spring(damping: 4)
         
-        XCTAssertEqual(editedDelay.options, containedAnimation.options)
+        XCTAssertEqual(editedDelay.allowsUserInteraction, true)
+        
+        XCTAssertEqual(editedDelay.allowsUserInteraction, containedAnimation.allowsUserInteraction)
         XCTAssertEqual(editedDelay.dampingRatio, spring.dampingRatio)
         XCTAssertNotEqual(springed.dampingRatio, spring.dampingRatio)
         XCTAssertEqual(springed.delay, delay.delay)
@@ -156,25 +160,23 @@ class BuilderTests: AnimationPlannerTests {
                 Animate(duration: duration) {
                     self.performRandomAnimation()
                 }
-                .options(.allowAnimatedContent)
+                .allowUserInteraction()
             }
             
         }
     }
     
     func testBuilderContainerModifiers() {
-        let totalDuration: TimeInterval = 1
-        let numberOfSteps: TimeInterval = 1
-        let duration = totalDuration / numberOfSteps
+        let duration: TimeInterval = 1
         
-        runAnimationBuilderTest(duration: totalDuration) { _, _ in
+        runAnimationBuilderTest(duration: duration) { _, _ in
             
             AnimationPlanner.plan {
                 Animate(duration: duration) {
                     self.performRandomAnimation()
                 }
                 .spring(damping: 0.82)
-                .options(.allowUserInteraction)
+                .allowUserInteraction()
             }
             
         }

--- a/Tests/AnimationPlannerTests/GroupTests.swift
+++ b/Tests/AnimationPlannerTests/GroupTests.swift
@@ -144,5 +144,35 @@ class GroupTests: AnimationPlannerTests {
             
         }
     }
+	
+    /// Animates multiple sequences simulatiously, each with an increasing offset in their contained animations
+    func testGroupsWithOffsetSequenceAnimations() {
+        let numberOfGroups: Int = 4
+        let animations = randomDurations(amount: 2)
+        let delayMultiplier: Double = 0.2
+        
+        let totalDelay: TimeInterval = Double(numberOfGroups - 1) * delayMultiplier
+        let totalDuration: TimeInterval = totalDelay + animations.reduce(0, { $0 + $1 })
+        
+        let views = (0..<numberOfGroups).map { _ in
+            newView()
+        }
+        
+        runAnimationBuilderTest(duration: totalDuration) { _, _ in
+            AnimationPlanner.group {
+                Loop(for: numberOfGroups) { index in
+                    let delay = Double(index) * delayMultiplier
+                    Sequence {
+                        Wait(delay)
+                        animations.mapAnimations { duration in
+                            Animate(duration: duration) {
+                                self.performRandomAnimation(on: views[index])
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
     
 }

--- a/Tests/AnimationPlannerTests/GroupTests.swift
+++ b/Tests/AnimationPlannerTests/GroupTests.swift
@@ -175,4 +175,33 @@ class GroupTests: AnimationPlannerTests {
         }
     }
     
+    /// Animates multiple sequences simulatiously, each with an increasinging delay added through a delay modifier
+    func testGroupsWithDelayedSequences() {
+        let numberOfGroups: Int = 4
+        let animations = randomDurations(amount: 2)
+        let delayMultiplier: Double = 0.2
+        
+        let totalDelay: TimeInterval = Double(numberOfGroups - 1) * delayMultiplier
+        let totalDuration: TimeInterval = totalDelay + animations.reduce(0, { $0 + $1 })
+        
+        let views = (0..<numberOfGroups).map { _ in
+            newView()
+        }
+        
+        runAnimationBuilderTest(duration: totalDuration) { _, _ in
+            AnimationPlanner.group {
+                Loop(for: numberOfGroups) { index in
+                    let delay = Double(index) * delayMultiplier
+                    Sequence {
+                        animations.mapAnimations { duration in
+                            Animate(duration: duration) {
+                                self.performRandomAnimation(on: views[index])
+                            }
+                        }
+                    }.delayed(delay)
+                }
+            }
+        }
+    }
+    
 }

--- a/Tests/AnimationPlannerTests/StoppingTests.swift
+++ b/Tests/AnimationPlannerTests/StoppingTests.swift
@@ -50,7 +50,7 @@ class StoppingTests: AnimationPlannerTests {
         let animations = randomDelayedAnimations(amount: 4)
         let totalDuration: TimeInterval = animations.reduce(0, { $0 + $1.totalDuration })
 
-        var runningSequence: RunningSequence? = nil
+        var runningSequence: RunningSequence?
         runningSequence = AnimationPlanner.plan {
             animations.mapAnimations { animation in
                 Wait(animation.delay)
@@ -59,7 +59,7 @@ class StoppingTests: AnimationPlannerTests {
                 }
             }
             
-            Extra { [weak runningSequence] in
+            Extra {
                 // Cancelling animation after planend animation
                 runningSequence?.stopAnimations()
             }

--- a/Tests/AnimationPlannerTests/StoppingTests.swift
+++ b/Tests/AnimationPlannerTests/StoppingTests.swift
@@ -1,0 +1,122 @@
+import AnimationPlanner
+import XCTest
+
+class StoppingTests: AnimationPlannerTests {
+    
+    func testWorkItemCancelling() {
+        runAnimationTest { completion, usedDuration, usedPrecision in
+            let workItem = DispatchWorkItem {
+                XCTFail("Scheduled and subsequently cancelled work item should never be executed")
+            }
+            workItem.notify(queue: .main) { [weak workItem] in
+                let finished = workItem?.isCancelled == false
+                XCTExpectFailure {
+                    completion(finished)
+                }
+            }
+            let delayTime: DispatchTime = .now() + usedDuration
+            let cancelTime: DispatchTime = .now() + usedDuration / 2
+            DispatchQueue.main.asyncAfter(deadline: delayTime, execute: workItem)
+            DispatchQueue.main.asyncAfter(deadline: cancelTime) {
+                workItem.cancel()
+            }
+        }
+    }
+    
+    func testExtraStopping() {
+        let duration = randomDuration
+        let runningSequence = AnimationPlanner.plan {
+            Wait(duration)
+            Extra {
+                XCTFail("Extra should never be called")
+            }
+        }
+        
+        let stopDelay = duration - durationPrecision
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + stopDelay) {
+            runningSequence.stopAnimations()
+        }
+        
+        runAnimationBuilderTest(duration: duration, expectFinished: false) { usedDuration, usedPrecision in
+            runningSequence
+        }
+    }
+    
+    func testBasicStopping() {
+        // Run a basic number of animations after which the sequence shoud be stopped.
+        // As the stopping is happening from an extra right after the expected animations
+        // the timing should be just right
+        let animations = randomDelayedAnimations(amount: 4)
+        let totalDuration: TimeInterval = animations.reduce(0, { $0 + $1.totalDuration })
+
+        var runningSequence: RunningSequence? = nil
+        runningSequence = AnimationPlanner.plan {
+            animations.mapAnimations { animation in
+                Wait(animation.delay)
+                Animate(duration: animation.duration) {
+                    self.performRandomAnimation()
+                }
+            }
+            
+            Extra { [weak runningSequence] in
+                // Cancelling animation after planend animation
+                runningSequence?.stopAnimations()
+            }
+            Wait(randomDuration)
+            Animate(duration: randomDuration) {
+                XCTFail("Animation should never be performed")
+            }
+            Wait(randomDuration)
+            Extra {
+                XCTFail("Extra should never be performed")
+            }
+        }
+        
+        runAnimationBuilderTest(duration: totalDuration, expectFinished: false) { usedDuration, usedPrecision in
+            runningSequence!
+        }
+    }
+    
+    func testGroupStopping() {
+        // Runs a number of sequences in parallel with each a specific number of animations
+        // Then halfway through the expected duration of the animations, the animations are
+        // stopped. Each animation that is executed after animations should be stopped trigger
+        // a failure.
+        
+        let numberOfSequences = 4
+        let numberOfAnimations = 4
+        let sequenceIndexMultiplier: TimeInterval = 0.5
+        let animations = randomDelayedAnimations(amount: numberOfAnimations)
+        let precision = durationPrecision * TimeInterval(numberOfSequences)
+        let totalDuration = animations.reduce(0, { $0 + $1.totalDuration }) + TimeInterval(numberOfSequences - 1) * sequenceIndexMultiplier
+        
+        let pauseDelay: TimeInterval = totalDuration / 2
+        let pauseOffset = CACurrentMediaTime() + pauseDelay
+        
+        let runningSequence = AnimationPlanner.group {
+            Loop(for: numberOfSequences) { sequenceIndex in
+                Sequence {
+                    let sequenceDelay = TimeInterval(sequenceIndex) * sequenceIndexMultiplier
+                    Wait(sequenceDelay)
+                    let view = newView()
+                    animations.enumerated().mapAnimations { index, animation in
+                        Wait(animation.delay)
+                        Animate(duration: animation.duration) {
+                            XCTAssert(CACurrentMediaTime() < (pauseOffset + durationPrecision))
+                            self.performRandomAnimation(on: view)
+                        }
+                    }
+                }
+            }
+        }
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + pauseDelay) {
+            runningSequence.stopAnimations()
+        }
+        
+        runAnimationBuilderTest(duration: pauseDelay, precision: precision, expectFinished: false) { _, _ in
+            runningSequence
+        }
+    }
+}


### PR DESCRIPTION
Notes to follow, but this PR fixes #17 and totally changes how animations are performed. Sub-animations (like those containing within a `Group` or a `Sequence`) are now cancelled as well.