### PR TITLE
Proper stopping

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Build
-      run: xcodebuild build -scheme 'AnimationPlanner' -destination 'platform=iOS Simulator,name=iPhone 14 Pro'
+      run: xcodebuild build -scheme 'AnimationPlanner' -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14 Pro'
     - name: Run tests
-      run: xcodebuild test -scheme 'AnimationPlanner' -destination 'platform=iOS Simulator,name=iPhone 14 Pro'
+      run: xcodebuild test -scheme 'AnimationPlanner' -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 14 Pro'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Build
-      run: xcodebuild build -scheme 'AnimationPlanner' -destination 'platform=iOS Simulator,name=iPhone 15'
+      run: xcodebuild build -scheme 'AnimationPlanner' -destination 'platform=iOS Simulator,name=iPhone 14 Pro'
     - name: Run tests
-      run: xcodebuild test -scheme 'AnimationPlanner' -destination 'platform=iOS Simulator,name=iPhone 15'
+      run: xcodebuild test -scheme 'AnimationPlanner' -destination 'platform=iOS Simulator,name=iPhone 14 Pro'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,6 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Build
-      run: xcodebuild build -scheme 'AnimationPlanner' -destination 'platform=iOS Simulator,name=iPhone 13'
+      run: xcodebuild build -scheme 'AnimationPlanner' -destination 'platform=iOS Simulator,name=iPhone 15'
     - name: Run tests
-      run: xcodebuild test -scheme 'AnimationPlanner' -destination 'platform=iOS Simulator,name=iPhone 13'
+      run: xcodebuild test -scheme 'AnimationPlanner' -destination 'platform=iOS Simulator,name=iPhone 15'

--- a/Sample App/AnimationPlanner-Sample.xcodeproj/project.pbxproj
+++ b/Sample App/AnimationPlanner-Sample.xcodeproj/project.pbxproj
@@ -17,7 +17,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		3E5C6DA62848C27B00720FE8 /* CAMediaTimingFunction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CAMediaTimingFunction.swift; sourceTree = "<group>"; };
 		3EF52D592848AEC7000F8222 /* AnimationPlanner-Sample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "AnimationPlanner-Sample.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3EF52D5C2848AEC7000F8222 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		3EF52D5E2848AEC7000F8222 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -72,7 +71,6 @@
 				3EF52D5C2848AEC7000F8222 /* AppDelegate.swift */,
 				3EF52D5E2848AEC7000F8222 /* SceneDelegate.swift */,
 				3EF52D602848AEC7000F8222 /* ViewController.swift */,
-				3E5C6DA62848C27B00720FE8 /* CAMediaTimingFunction.swift */,
 				3EF52D622848AEC7000F8222 /* Main.storyboard */,
 				3EF52D652848AEC8000F8222 /* Assets.xcassets */,
 				3EF52D672848AEC8000F8222 /* LaunchScreen.storyboard */,
@@ -120,7 +118,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1340;
-				LastUpgradeCheck = 1340;
+				LastUpgradeCheck = 1520;
 				TargetAttributes = {
 					3EF52D582848AEC7000F8222 = {
 						CreatedOnToolsVersion = 13.4;
@@ -227,6 +225,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -287,6 +286,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;

--- a/Sample App/AnimationPlanner-Sample/ViewController.swift
+++ b/Sample App/AnimationPlanner-Sample/ViewController.swift
@@ -9,48 +9,64 @@ import UIKit
 import AnimationPlanner
 
 class ViewController: UIViewController {
-
+    
     lazy var subview: UIView = {
         let view = UIView(frame: CGRect(x: 0, y: 0, width: 100, height: 100))
         view.layer.cornerCurve = .continuous
         return view
     }()
     
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        view.addSubview(subview)
-    }
-
+    lazy var stopButton = newStopButton()
+    lazy var resetButton = newResetButton()
+    
+    // Sequence currently performing animations
+    var runningSequence: RunningSequence?
+    
+    let testStopping: Bool = true // Set to true to display buttons to stop and reset animations
+    
     let performComplexAnimation: Bool = false // Set to true to run a more complex animation
-
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
+    
+    func performAnimations() {
+        resetButton.isEnabled = false
         if performComplexAnimation {
-            runComplexBulderAnimation()
+            runComplexBuilderAnimation()
         } else {
             runSimpleBuilderAnimation()
         }
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        performAnimations()
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.addSubview(subview)
+        
+        guard testStopping else {
+            return
+        }
+        view.addSubview(stopButton)
+        view.addSubview(resetButton)
+        stopButton.translatesAutoresizingMaskIntoConstraints = false
+        resetButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            stopButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+            stopButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            stopButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerXAnchor, constant: -8),
+            resetButton.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.centerXAnchor, constant: 8),
+            resetButton.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+            resetButton.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor)
+        ])
     }
 }
 
 extension ViewController {
     
-    func setInitialSubviewState() -> UIView {
-        subview.alpha = 0
-        subview.transform = .identity
-        subview.frame.size = CGSize(width: 100, height: 100)
-        subview.center.x = view.bounds.midX
-        subview.frame.origin.y = view.bounds.minY
-        subview.backgroundColor = .systemOrange
-        subview.layer.cornerRadius = 16
-        subview.layer.borderWidth = 0
-        subview.layer.borderColor = nil
-        return subview
-    }
-    
     func runSimpleBuilderAnimation() {
         let view = setInitialSubviewState()
-        AnimationPlanner.plan {
+        runningSequence = AnimationPlanner.plan {
             Wait(0.35) // A delay waits for the given amount of seconds to start the next step
             Animate(duration: 0.32, timingFunction: .quintOut) {
                 view.alpha = 1
@@ -75,16 +91,18 @@ extension ViewController {
                 view.frame.origin.y = self.view.bounds.maxY
             }.timingFunction(.circIn)
         }.onComplete { finished in
-            // Just to keep the flow going, let‘s run the animation again
-            self.runSimpleBuilderAnimation()
+            if finished {
+                // Just to keep the flow going, let‘s run the animation again
+                self.runSimpleBuilderAnimation()
+            }
         }
     }
     
     
-    func runComplexBulderAnimation() {
+    func runComplexBuilderAnimation() {
         var sneakyCopy: UIView! // Don‘t worry, you‘ll see later
         
-        AnimationPlanner.plan {
+        runningSequence = AnimationPlanner.plan {
             let quarterHeight = view.bounds.height / 4
             let view = setInitialSubviewState()
             
@@ -112,9 +130,9 @@ extension ViewController {
             
             let loopCount = 4
             
-            // Adding mulitple steps can be done through the `Loop` struct
-            // or by adding `.animateLoop { }` to any sequence
-            Loop.through(1...loopCount) { index in
+            // Adding multiple steps can be done with a for-in statement
+            // or by adding `.mapSequence { }` or `.mapGroup { }` to any sequence
+            for index in 1...loopCount {
                 let offset = CGFloat(index) / CGFloat(loopCount)
                 let reversed = 1 - offset
                 Animate(duration: 0.32) {
@@ -183,16 +201,33 @@ extension ViewController {
                 sneakyCopy?.transform = view.transform.translatedBy(x: 0, y: quarterHeight)
             }
         }.onComplete { finished in
-            self.runComplexBulderAnimation()
+            if finished {
+                sneakyCopy.removeFromSuperview()
+                self.runComplexBuilderAnimation()
+            }
         }
     }
 }
 
 extension ViewController {
+    
+    func setInitialSubviewState() -> UIView {
+        subview.alpha = 0
+        subview.transform = .identity
+        subview.frame.size = CGSize(width: 100, height: 100)
+        subview.center.x = view.bounds.midX
+        subview.frame.origin.y = view.bounds.minY
+        subview.backgroundColor = .systemOrange
+        subview.layer.cornerRadius = 16
+        subview.layer.borderWidth = 0
+        subview.layer.borderColor = nil
+        return subview
+    }
+    
     /// Adds a custom shake animation sequence on the provided view
     /// - Parameter view: View to which the transform should be applied
     /// - Returns: Animations to be added to the sequence
-    @AnimationBuilder
+    @SequenceBuilder
     func addShakeSequence(shaking view: UIView) -> [SequenceAnimatable] {
         var baseTransform: CGAffineTransform = .identity
         
@@ -201,7 +236,7 @@ extension ViewController {
         let values = (0..<count).map { CGFloat($0) / CGFloat(count) }.map { $0 * maxRadius }
         
         Extra { baseTransform = view.transform }
-        Loop.through(values) { radius in
+        for radius in values {
             Animate(duration: 0.015) {
                 view.transform = baseTransform
                     .translatedBy(
@@ -210,6 +245,34 @@ extension ViewController {
                     )
             }.timingFunction(.quintOut)
         }
+    }
+}
+
+private extension ViewController {
+    
+    func newStopButton() -> UIButton {
+        var configuration = UIButton.Configuration.filled()
+        configuration.buttonSize = .large
+        configuration.baseBackgroundColor = .systemRed
+        configuration.cornerStyle = .large
+        configuration.title = "Stop"
+        return UIButton(configuration: configuration, primaryAction: UIAction { [unowned self] _ in
+            runningSequence?.stopAnimations()
+            resetButton.isEnabled = true
+        })
+    }
+    
+    func newResetButton() -> UIButton {
+        var configuration = UIButton.Configuration.filled()
+        configuration.buttonSize = .large
+        configuration.baseBackgroundColor = .systemGreen
+        configuration.cornerStyle = .large
+        configuration.title = "Reset"
+        let button = UIButton(configuration: configuration, primaryAction: UIAction { [unowned self] _ in
+            performAnimations()
+        })
+        button.isEnabled = false
+        return button
     }
 }
 
@@ -223,7 +286,7 @@ extension UIView {
             
             let unarchiver = try NSKeyedUnarchiver(forReadingFrom: data)
             unarchiver.requiresSecureCoding = false
-
+            
             guard let view = unarchiver.decodeObject() as? Self else {
                 return nil
             }
@@ -237,4 +300,3 @@ extension UIView {
         }
     }
 }
-

--- a/Sources/AnimationPlanner/Animations/Animate.swift
+++ b/Sources/AnimationPlanner/Animations/Animate.swift
@@ -56,4 +56,9 @@ extension Animate: PerformsAnimations {
             createAnimations(completion)
         }
     }
+    
+    public func stop() {
+        /// Just run animation again but ridiculously short and from current state
+        UIView.animate(withDuration: 0.001, delay: 0, options: .beginFromCurrentState, animations: changes)
+    }
 }

--- a/Sources/AnimationPlanner/Animations/Animate.swift
+++ b/Sources/AnimationPlanner/Animations/Animate.swift
@@ -88,8 +88,8 @@ extension Animate: PerformsAnimations {
                 ],
                 animations: changes
             )
+            stopper.stopHandler?()
         }
-        stopper.stopHandler?()
         stopper.isStopped = true
     }
 }

--- a/Sources/AnimationPlanner/Animations/AnimateDelayed.swift
+++ b/Sources/AnimationPlanner/Animations/AnimateDelayed.swift
@@ -53,4 +53,8 @@ extension AnimateDelayed: PerformsAnimations where Contained: PerformsAnimations
     public func animate(delay leadingDelay: TimeInterval, completion: ((Bool) -> Void)?) {
         animation.animate(delay: delay + leadingDelay, completion: completion)
     }
+    
+    public func stop() {
+        animation.stop()
+    }
 }

--- a/Sources/AnimationPlanner/Animations/AnimateSpring.swift
+++ b/Sources/AnimationPlanner/Animations/AnimateSpring.swift
@@ -53,4 +53,8 @@ extension AnimateSpring: PerformsAnimations {
             completion: completion
         )
     }
+    
+    public func stop() {
+        animation.stop()
+    }
 }

--- a/Sources/AnimationPlanner/Animations/Extra.swift
+++ b/Sources/AnimationPlanner/Animations/Extra.swift
@@ -3,42 +3,35 @@ import UIKit
 /// Performs the provided handler in between your actual animations.
 /// Typically used for setting up state before an animation or creating side-effects like haptic feedback.
 public struct Extra: SequenceAnimatable, GroupAnimatable {
-    private let id = UUID()
     public let duration: TimeInterval = 0
     
-    public var perform: () -> Void
+    /// Work item used for actually executing the closure
+    private let workItem: DispatchWorkItem
+    
     public init(perform: @escaping () -> Void) {
-        self.perform = perform
+        workItem = DispatchWorkItem(block: perform)
     }
-}
-
-extension Extra {
-    private static var allowedAnimations: Set<UUID> = []
 }
 
 extension Extra: PerformsAnimations {
     public func animate(delay leadingDelay: TimeInterval, completion: ((Bool) -> Void)?) {
         let timing = timingParameters(leadingDelay: leadingDelay)
-        Self.allowedAnimations.insert(id)
-        let animation: () -> Void = {
-            guard Self.allowedAnimations.contains(id) else {
-                completion?(false)
-                return
-            }
-            self.perform()
-            Self.allowedAnimations.remove(id)
-            completion?(true)
-        }
+        
         guard timing.delay > 0 else {
-            animation()
+            workItem.perform()
+            completion?(true)
             return
         }
-        DispatchQueue.main.asyncAfter(deadline: .now() + timing.delay) {
-            animation()
+        
+        workItem.notify(queue: .main) { [weak workItem] in
+            let isFinished = workItem?.isCancelled != false
+            completion?(isFinished)
         }
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + timing.delay, execute: workItem)
     }
     
     public func stop() {
-        Self.allowedAnimations.remove(id)
+        workItem.cancel()
     }
 }

--- a/Sources/AnimationPlanner/Animations/Extra.swift
+++ b/Sources/AnimationPlanner/Animations/Extra.swift
@@ -27,4 +27,10 @@ extension Extra: PerformsAnimations {
             animation()
         }
     }
+    
+    public func stop() {
+        // No-op:
+        // 1. Either fires immediately so can’t be stopped
+        // 2. Is invoked with a delay and queue can’t be stopped
+    }
 }

--- a/Sources/AnimationPlanner/Animations/Extra.swift
+++ b/Sources/AnimationPlanner/Animations/Extra.swift
@@ -24,7 +24,7 @@ extension Extra: PerformsAnimations {
         }
         
         workItem.notify(queue: .main) { [weak workItem] in
-            let isFinished = workItem?.isCancelled != false
+            let isFinished = workItem?.isCancelled != true
             completion?(isFinished)
         }
         

--- a/Sources/AnimationPlanner/Animations/Group.swift
+++ b/Sources/AnimationPlanner/Animations/Group.swift
@@ -44,4 +44,10 @@ extension Group: PerformsAnimations {
         }
         longestAnimation.animate(delay: delay, completion: completion)
     }
+    
+    public func stop() {
+        for animation in animations.compactMap({ $0 as? PerformsAnimations }) {
+            animation.stop()
+        }
+    }
 }

--- a/Sources/AnimationPlanner/Animations/Sequence.swift
+++ b/Sources/AnimationPlanner/Animations/Sequence.swift
@@ -33,4 +33,8 @@ extension Sequence: PerformsAnimations {
             }
             .animate(delay: delay)
     }
+    
+    public func stop() {
+        runningSequence.stopAnimations()
+    }
 }

--- a/Sources/AnimationPlanner/Protocols/AnimationContainer.swift
+++ b/Sources/AnimationPlanner/Protocols/AnimationContainer.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-/// Adds custom behaviour on top of any contained animation. Forwards all required ``Animation`` properties
+/// Adds custom behavior on top of any contained animation. Forwards all required ``Animation`` properties
 /// to the contained animation when necessary.
 public protocol AnimationContainer {
     /// Animation type contained by ``AnimationContainer``

--- a/Sources/AnimationPlanner/Protocols/AnimationModifiers.swift
+++ b/Sources/AnimationPlanner/Protocols/AnimationModifiers.swift
@@ -13,6 +13,9 @@ public protocol AnimationModifiers: Animation {
     /// - Note: Using `.repeats` will break expected behavior when used in a sequence
     func options(_ options: UIView.AnimationOptions) -> Self
     
+    /// Enables interaction on your parent views while this animation is running
+    func allowUserInteraction() -> Self
+    
     /// Sets a `CAMediaTimingFunction` for the animation. Overwrites possible previously set functions.
     ///
     /// Overrides any animation curves previously set with ``timingFunction(_:)``
@@ -35,6 +38,9 @@ extension Animate: AnimationModifiers {
     public func options(_ options: UIView.AnimationOptions) -> Self {
         // Update options by creating a union of existing options
         mutate { $0.options = $0.options?.union(options) ?? options }
+    }
+    public func allowUserInteraction() -> Animate {
+        mutate { $0.options = ($0.options ?? []).union(.allowUserInteraction) }
     }
     public func timingFunction(_ function: CAMediaTimingFunction) -> Self {
         mutate { $0.timingFunction = function}
@@ -127,6 +133,9 @@ extension AnimateSpring: AnimationModifiers where Contained: AnimationModifiers 
     public func options(_ options: UIView.AnimationOptions) -> Self {
         mutate { $0.animation = animation.options(options) }
     }
+    public func allowUserInteraction() -> AnimateSpring<Springed> {
+        mutate { $0.animation = animation.allowUserInteraction() }
+    }
     public func timingFunction(_ function: CAMediaTimingFunction) -> Self {
         mutate { $0.animation = animation.timingFunction(function) }
     }
@@ -139,6 +148,9 @@ extension AnimateDelayed: Mutable { }
 extension AnimateDelayed: AnimationModifiers where Contained: Animation & AnimationModifiers {
     public func options(_ options: UIView.AnimationOptions) -> Self {
         mutate { $0.animation = animation.options(options) }
+    }
+    public func allowUserInteraction() -> AnimateDelayed<Delayed> {
+        mutate { $0.animation = animation.allowUserInteraction() }
     }
     public func timingFunction(_ function: CAMediaTimingFunction) -> Self {
         mutate { $0.animation = animation.timingFunction(function) }

--- a/Sources/AnimationPlanner/Protocols/AnimationModifiers.swift
+++ b/Sources/AnimationPlanner/Protocols/AnimationModifiers.swift
@@ -117,6 +117,7 @@ extension Mutable {
 }
 
 extension Animate: Mutable { }
+extension Extra: Mutable { }
 
 extension AnimateSpring: Mutable { }
 extension AnimateSpring: AnimationModifiers where Contained: AnimationModifiers {

--- a/Sources/AnimationPlanner/Protocols/PerformsAnimations.swift
+++ b/Sources/AnimationPlanner/Protocols/PerformsAnimations.swift
@@ -10,6 +10,9 @@ public protocol PerformsAnimations {
     ///   - completion: Optional closure called when animation completes
     func animate(delay leadingDelay: TimeInterval, completion: ((_ finished: Bool) -> Void)?)
     
+    /// Cancels any currently running animations
+    func stop()
+    
     /// Queries the animation and possible contained animations to find the correct timing values to use to create an actual animation
     /// - Parameter leadingDelay: Delay to add before performing animation
     /// - Returns: Tuple containing a delay and duration in seconds

--- a/Sources/AnimationPlanner/RunningSequence.swift
+++ b/Sources/AnimationPlanner/RunningSequence.swift
@@ -9,7 +9,7 @@ public class RunningSequence {
         /// Sequence is performing animations
         case running
         /// Sequence has completed animations have completed
-        /// - Parameter finished: Wether animations have properly finished
+        /// - Parameter finished: Whether animations have properly finished
         case completed(finished: Bool)
         /// Sequence has been manually stopped
         case stopped

--- a/Tests/AnimationPlannerTests/AnimationPlannerTests.swift
+++ b/Tests/AnimationPlannerTests/AnimationPlannerTests.swift
@@ -79,7 +79,7 @@ class AnimationPlannerTests: XCTestCase {
         
         animations(completion, duration, precision)
         
-        waitForExpectations(timeout: duration + precision * 2)
+        wait(for: [finishedExpectation], timeout: duration + precision * 2)
     }
 }
 

--- a/Tests/AnimationPlannerTests/BuilderTests.swift
+++ b/Tests/AnimationPlannerTests/BuilderTests.swift
@@ -14,6 +14,10 @@ class BuilderTests: AnimationPlannerTests {
         let simplerSpring = AnimateSpring(duration: 1, dampingRatio: 2)
         XCTAssertEqual(spring.dampingRatio, simplerSpring.dampingRatio)
         XCTAssertEqual(spring.duration, simplerSpring.duration)
+        let springOptions = spring.options ?? []
+        XCTAssertFalse(springOptions.contains(.allowUserInteraction))
+        let editedOptions = spring.allowUserInteraction().options ?? []
+        XCTAssertTrue(editedOptions.contains(.allowUserInteraction))
         
         let delay = spring.delayed(3)
         XCTAssertEqual(delay.duration, spring.duration + delay.delay)

--- a/Tests/AnimationPlannerTests/ComplexAnimationTests.swift
+++ b/Tests/AnimationPlannerTests/ComplexAnimationTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 class ComplexAnimationTest: AnimationPlannerTests {
     
-    /// Creates a pretty complex animation with mutliple groups each containing multiple sequences
+    /// Creates a pretty complex animation with multiple groups each containing multiple sequences
     /// Groups can contain sequences that perform their animations in sequence, but each sequence
     /// is running at the same time in each group
     func testSequenceGroup() {

--- a/Tests/AnimationPlannerTests/GroupTests.swift
+++ b/Tests/AnimationPlannerTests/GroupTests.swift
@@ -180,4 +180,63 @@ class GroupTests: AnimationPlannerTests {
 
         }
     }
+    
+    /// Animates multiple sequences simultaneously, each with an increasing offset in their contained animations
+    func testGroupsWithOffsetSequenceAnimations() {
+        let numberOfGroups: Int = 4
+        let animations = randomDurations(amount: 2)
+        let delayMultiplier: Double = 0.2
+        
+        let totalDelay: TimeInterval = Double(numberOfGroups - 1) * delayMultiplier
+        let totalDuration: TimeInterval = totalDelay + animations.reduce(0, { $0 + $1 })
+        
+        let views = (0..<numberOfGroups).map { _ in
+            newView()
+        }
+        
+        runAnimationBuilderTest(duration: totalDuration) { _, _ in
+            AnimationPlanner.group {
+                for index in 0..<numberOfGroups {
+                    let delay = Double(index) * delayMultiplier
+                    Sequence {
+                        Wait(delay)
+                        for duration in animations {
+                            Animate(duration: duration) {
+                                self.performRandomAnimation(on: views[index])
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+    /// Animates multiple sequences simultaneously, each with an increasing delay added through a delay modifier
+    func testGroupsWithDelayedSequences() {
+        let numberOfGroups: Int = 4
+        let animations = randomDurations(amount: 2)
+        let delayMultiplier: Double = 0.2
+        
+        let totalDelay: TimeInterval = Double(numberOfGroups - 1) * delayMultiplier
+        let totalDuration: TimeInterval = totalDelay + animations.reduce(0, { $0 + $1 })
+        
+        let views = (0..<numberOfGroups).map { _ in
+            newView()
+        }
+        
+        runAnimationBuilderTest(duration: totalDuration) { _, _ in
+            AnimationPlanner.group {
+                for index in 0..<numberOfGroups {
+                    let delay = Double(index) * delayMultiplier
+                    Sequence {
+                        for duration in animations {
+                            Animate(duration: duration) {
+                                self.performRandomAnimation(on: views[index])
+                            }
+                        }
+                    }.delayed(delay)
+                }
+            }
+        }
+    }
 }

--- a/Tests/AnimationPlannerTests/StoppingTests.swift
+++ b/Tests/AnimationPlannerTests/StoppingTests.swift
@@ -1,0 +1,122 @@
+import AnimationPlanner
+import XCTest
+
+class StoppingTests: AnimationPlannerTests {
+    
+    func testWorkItemCancelling() {
+        runAnimationTest { completion, usedDuration, usedPrecision in
+            let workItem = DispatchWorkItem {
+                XCTFail("Scheduled and subsequently cancelled work item should never be executed")
+            }
+            workItem.notify(queue: .main) { [weak workItem] in
+                let finished = workItem?.isCancelled == false
+                XCTExpectFailure {
+                    completion(finished)
+                }
+            }
+            let delayTime: DispatchTime = .now() + usedDuration
+            let cancelTime: DispatchTime = .now() + usedDuration / 2
+            DispatchQueue.main.asyncAfter(deadline: delayTime, execute: workItem)
+            DispatchQueue.main.asyncAfter(deadline: cancelTime) {
+                workItem.cancel()
+            }
+        }
+    }
+    
+    func testExtraStopping() {
+        let duration = randomDuration
+        let runningSequence = AnimationPlanner.plan {
+            Wait(duration)
+            Extra {
+                XCTFail("Extra should never be called")
+            }
+        }
+        
+        let stopDelay = duration - durationPrecision
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + stopDelay) {
+            runningSequence.stopAnimations()
+        }
+        
+        runAnimationBuilderTest(duration: duration, expectFinished: false) { usedDuration, usedPrecision in
+            runningSequence
+        }
+    }
+    
+    func testBasicStopping() {
+        // Run a basic number of animations after which the sequence should be stopped.
+        // As the stopping is happening from an extra right after the expected animations
+        // the timing should be just right
+        let animations = randomDelayedAnimations(amount: 4)
+        let totalDuration: TimeInterval = animations.reduce(0, { $0 + $1.totalDuration })
+        
+        var runningSequence: RunningSequence?
+        runningSequence = AnimationPlanner.plan {
+            for animation in animations {
+                Wait(animation.delay)
+                Animate(duration: animation.duration) {
+                    self.performRandomAnimation()
+                }
+            }
+            
+            Extra {
+                // Cancelling animation after planen animation
+                runningSequence?.stopAnimations()
+            }
+            Wait(randomDuration)
+            Animate(duration: randomDuration) {
+                XCTFail("Animation should never be performed")
+            }
+            Wait(randomDuration)
+            Extra {
+                XCTFail("Extra should never be performed")
+            }
+        }
+        
+        runAnimationBuilderTest(duration: totalDuration, expectFinished: false) { usedDuration, usedPrecision in
+            runningSequence!
+        }
+    }
+    
+    func testGroupStopping() {
+        // Runs a number of sequences in parallel with each a specific number of animations
+        // Then halfway through the expected duration of the animations, the animations are
+        // stopped. Each animation that is executed after animations should be stopped trigger
+        // a failure.
+        
+        let numberOfSequences = 4
+        let numberOfAnimations = 4
+        let sequenceIndexMultiplier: TimeInterval = 0.5
+        let animations = randomDelayedAnimations(amount: numberOfAnimations)
+        let precision = durationPrecision * TimeInterval(numberOfSequences)
+        let totalDuration = animations.reduce(0, { $0 + $1.totalDuration }) + TimeInterval(numberOfSequences - 1) * sequenceIndexMultiplier
+        
+        let pauseDelay: TimeInterval = totalDuration / 2
+        let pauseOffset = CACurrentMediaTime() + pauseDelay
+        
+        let runningSequence = AnimationPlanner.group {
+            for sequenceIndex in 0..<numberOfSequences {
+                Sequence {
+                    let sequenceDelay = TimeInterval(sequenceIndex) * sequenceIndexMultiplier
+                    Wait(sequenceDelay)
+                    let view = newView()
+                    for animation in animations {
+                        Wait(animation.delay)
+                        Animate(duration: animation.duration) {
+                            XCTAssert(CACurrentMediaTime() < (pauseOffset + durationPrecision))
+                            self.performRandomAnimation(on: view)
+                        }
+                    }
+                }
+            }
+        }
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + pauseDelay) {
+            runningSequence.stopAnimations()
+        }
+        
+        runAnimationBuilderTest(duration: pauseDelay, precision: precision, expectFinished: false) { _, _ in
+            runningSequence
+        }
+    }
+}

--- a/Tests/AnimationPlannerTests/StoppingTests.swift
+++ b/Tests/AnimationPlannerTests/StoppingTests.swift
@@ -47,7 +47,7 @@ class StoppingTests: AnimationPlannerTests {
         runAnimationBuilderTest(duration: stopDelay, expectFinished: false) { usedDuration, usedPrecision in
             runningSequence
         }
-        wait(for: [expectation])
+        wait(for: [expectation], timeout: duration + durationPrecision)
     }
     
     func testBasicStopping() {

--- a/Tests/AnimationPlannerTests/StoppingTests.swift
+++ b/Tests/AnimationPlannerTests/StoppingTests.swift
@@ -60,7 +60,7 @@ class StoppingTests: AnimationPlannerTests {
             }
             
             Extra {
-                // Cancelling animation after planen animation
+                // Cancelling animation after planned animation
                 runningSequence?.stopAnimations()
             }
             Wait(randomDuration)

--- a/Tests/AnimationPlannerTests/StoppingTests.swift
+++ b/Tests/AnimationPlannerTests/StoppingTests.swift
@@ -86,9 +86,9 @@ class StoppingTests: AnimationPlannerTests {
     }
     
     func testGroupStopping() {
-        // Runs a number of sequences in parallel with each a specific number of animations.
+        // Runs a number of sequences in parallel with each a specific number of animations
         // Then halfway through the expected duration of the animations, the animations are
-        // stopped. Each Extra that is executed after animations that should be stopped triggers
+        // stopped. Each animation that is executed after animations should be stopped triggers
         // a failure.
         
         let numberOfSequences = 4
@@ -110,10 +110,8 @@ class StoppingTests: AnimationPlannerTests {
                     for animation in animations {
                         Wait(animation.delay)
                         Animate(duration: animation.duration) {
-                            self.performRandomAnimation(on: view)
-                        }
-                        Extra {
                             XCTAssert(CACurrentMediaTime() < (pauseOffset + durationPrecision))
+                            self.performRandomAnimation(on: view)
                         }
                     }
                 }


### PR DESCRIPTION
Improved behavior of stopping running sequences. Introduces a `stop()` method to `PerformsAnimations` that should stop any currently running animations.

For long-running or repeating animations, `onStopped(_ stopHandler:)` is available for all animations so each animated view can be manually stopped by calling `view.layer.removeAllAnimations()`.