### PR TITLE
Perform Group’s animations in defined order

### DIFF
--- a/Sources/AnimationPlanner/Animations/Group.swift
+++ b/Sources/AnimationPlanner/Animations/Group.swift
@@ -28,21 +28,21 @@ public struct Group: SequenceAnimatable {
 extension Group: PerformsAnimations {
     
     public func animate(delay: TimeInterval, completion: ((Bool) -> Void)?) {
-        var sortedAnimations = animations
-            .sorted { $0.duration < $1.duration }
-            .compactMap { $0 as? PerformsAnimations }
-        
-        guard !sortedAnimations.isEmpty else {
+        let animations = animations.compactMap { $0 as? PerformsAnimations }
+        guard let longestDuration = animations.map(\.duration).max() else {
             completion?(true)
             return
         }
+        var hasAddedCompletionHandler: Bool = false
         
-        let longestAnimation = sortedAnimations.removeLast()
-        
-        sortedAnimations.forEach { animation in
-            animation.animate(delay: delay, completion: nil)
+        for animation in animations {
+            if animation.duration >= longestDuration, !hasAddedCompletionHandler {
+                hasAddedCompletionHandler = true
+                animation.animate(delay: delay, completion: completion)
+            } else {
+                animation.animate(delay: delay, completion: nil)
+            }
         }
-        longestAnimation.animate(delay: delay, completion: completion)
     }
     
     public func stop() {

--- a/Sources/AnimationPlanner/Protocols/PerformsAnimations.swift
+++ b/Sources/AnimationPlanner/Protocols/PerformsAnimations.swift
@@ -2,7 +2,7 @@ import UIKit
 
 /// Creates actual `UIView` animations for all animation structs. Implement ``animate(delay:completion:)`` to make sure any custom animation creates an actual animation.
 /// Use the default implementation of ``timingParameters(leadingDelay:)-2swvd`` to get the most accurate timing parameters for your animation so any set delay isn't missed.
-public protocol PerformsAnimations {
+public protocol PerformsAnimations: Animatable {
     /// Perform the actual animation
     /// - Parameters:
     ///   - delay: Any delay accumulated (from preceding ``Wait`` structs) leading up to the animation.
@@ -22,13 +22,11 @@ public protocol PerformsAnimations {
 extension PerformsAnimations {
     
     public func timingParameters(leadingDelay: TimeInterval) -> (delay: TimeInterval, duration: TimeInterval) {
-        var parameters = (delay: leadingDelay, duration: TimeInterval(0))
+        var parameters = (delay: leadingDelay, duration: duration)
         
         if let delayed = self as? DelayedAnimatable {
             parameters.delay += delayed.delay
             parameters.duration = delayed.originalDuration
-        } else if let animation = self as? Animatable {
-            parameters.duration = animation.duration
         }
         return parameters
     }

--- a/Sources/AnimationPlanner/RunningSequence.swift
+++ b/Sources/AnimationPlanner/RunningSequence.swift
@@ -111,7 +111,7 @@ extension RunningSequence {
         }
         
         remainingAnimations = Array(impendingAnimations.dropFirst())
-        let duration = (animation as? Animatable)?.duration ?? 0
+        let duration = animation.duration
         let completionDuration = duration + leadingDelay
         
         let startTime = CACurrentMediaTime()


### PR DESCRIPTION
Updated the way the animations in a `Group` are started, so the first animation that runs is always the first defined animation